### PR TITLE
Fixed css and js references for non-root pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,14 +11,14 @@
     <title>{{ site.title }} {% if page.title %} | {{ page.title }}{% endif %}</title>
 
     <!-- Bootstrap Core CSS -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="/css/grayscale.css" rel="stylesheet">
-    <link href="/css/timeline.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/css/grayscale.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/css/timeline.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
-    <link href="/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="{{ site.baseurl }}/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,14 +11,14 @@
     <title>{{ site.title }} {% if page.title %} | {{ page.title }}{% endif %}</title>
 
     <!-- Bootstrap Core CSS -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="css/grayscale.css" rel="stylesheet">
-    <link href="css/timeline.css" rel="stylesheet">
+    <link href="/css/grayscale.css" rel="stylesheet">
+    <link href="/css/timeline.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
-    <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
 

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,14 +1,14 @@
     <!-- jQuery -->
-    <script src="/js/jquery.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="{{ site.baseurl }}/js/bootstrap.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="/js/jquery.easing.min.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.easing.min.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="/js/grayscale.js"></script>
+    <script src="{{ site.baseurl }}/js/grayscale.js"></script>
 
     {% if site.google-tracking-id %}
     <script>

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,14 +1,14 @@
     <!-- jQuery -->
-    <script src="js/jquery.js"></script>
+    <script src="/js/jquery.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="js/bootstrap.min.js"></script>
+    <script src="/js/bootstrap.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="js/jquery.easing.min.js"></script>
+    <script src="/js/jquery.easing.min.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="js/grayscale.js"></script>
+    <script src="/js/grayscale.js"></script>
 
     {% if site.google-tracking-id %}
     <script>


### PR DESCRIPTION
Hi,

If a non-root page includes the header.html then the references to css and js files are broken because the paths are relative.

Fix: Added the root character in front of the css and js inclusions.

:panos
